### PR TITLE
Reduce crate size significantly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ repository = "https://github.com/scepter914/simple-image-interface-rs"
 license = "MIT"
 readme = "README.md"
 edition = "2018"
+include = ["src/lib.rs", "LICENSE", "README.md"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
Here is the output of `cargo diet`:

```
cargo diet
┌──────────────────────┬─────────────┐
│ Removed File         │ Size (Byte) │
├──────────────────────┼─────────────┤
│ .gitignore           │         457 │
│ examples/examples.rs │        1741 │
│ tests/tests.rs       │        2044 │
│ data/sample_80.png   │     1202974 │
│ data/from_raw.png    │     2316481 │
│ data/random_ball.mp4 │     3753346 │
└──────────────────────┴─────────────┘
Saved 100% or 7.3 MB in 6 files (of 7.3 MB and 10 files in entire crate)
```

Please let me know if you need any changes.